### PR TITLE
Version 1.2.34

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,9 @@
-### Version 1.2.34 ###
+### Version 1.2.34 (25.02.2024) ###
 * Leser und Vorsitz -Personen können gelöscht werden.
 * Vorträge 42, 70, 108 aktualisiert.
 * Meine Redner: neuer Filter "nur gewähltes Jahr anzeigen"
 * Excel Kontaktliste: Einträge am 31.12. wurden nicht ausgegeben
+* Bug behoben: Wenn ein Vortrag von einem Redner gelöscht wird, er aber noch Einladungen zu diesem Thema hat, wurde der Vortrag nicht mehr gespeichert. Diese Vorträge wurden erstmal auf "Unbekannt" gesetzt. Du kannst den Fehler beheben, indem du unter  [Historie] -> [Aktivitäten] -> [Mein Plan] -> nach der jeweiligen Versammlung des eingeladenen Redners filterst und dir die Aktivitäten Historie anschaust. Sollte es bei dir zu diesem Fehler gekommen sein, wirst du beim Update darauf hingewiesen und die betroffenen Wochen werden dir angezeigt.
 
 ### Version 1.2.33 (30.09.2023) ###
 * Vorträge 112 und 131 gesperrt

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 ### Version 1.2.34 ###
 * Leser und Vorsitz -Personen können gelöscht werden.
 * Vorträge 42, 70, 108 aktualisiert.
+* Meine Redner: neuer Filter "nur gewähltes Jahr anzeigen"
+* Excel Kontaktliste: Einträge am 31.12. wurden nicht ausgegeben
 
 ### Version 1.2.33 (30.09.2023) ###
 * Vorträge 112 und 131 gesperrt

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ### Version 1.2.34 ###
 * Leser und Vorsitz -Personen können gelöscht werden.
+* Vorträge 42, 70, 108 aktualisiert.
 
 ### Version 1.2.33 (30.09.2023) ###
 * Vorträge 112 und 131 gesperrt

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+### Version 1.2.34 ###
+* Leser und Vorsitz -Personen können gelöscht werden.
+
 ### Version 1.2.33 (30.09.2023) ###
 * Vorträge 112 und 131 gesperrt
 * Vorträge 104,107,111 aktualisiert

--- a/Vortragsmanager/DataModels/MyGloabalSettings.cs
+++ b/Vortragsmanager/DataModels/MyGloabalSettings.cs
@@ -96,6 +96,11 @@ namespace Vortragsmanager.DataModels
 
         public bool ThemeIsDark { get; set; } = true;
 
+        public bool MeineRednerHistory { get; set; } = false;
+
+        public bool MeineRednerOneYearOnly { get; set; } = false;
+
+
         public void Read()
         {
             var configFile = Helper.Helper.AppFolderPath + "Settings.xml";

--- a/Vortragsmanager/Datamodels/DataContainer.cs
+++ b/Vortragsmanager/Datamodels/DataContainer.cs
@@ -1,12 +1,9 @@
-﻿using DevExpress.Mvvm;
-using DevExpress.Xpf.Core;
+﻿using DevExpress.Xpf.Core;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Linq;
 using System.Windows;
-using System.Xml.Serialization;
 using Vortragsmanager.Enums;
 using Vortragsmanager.Helper;
 using Vortragsmanager.Interface;
@@ -381,7 +378,7 @@ namespace Vortragsmanager.DataModels
 
         public static bool IsInitialized { get; set; }
 
-        public static bool IsDemo {  get; set; }
+        public static bool IsDemo { get; set; }
 
         public static Conregation MeineVersammlung
         {

--- a/Vortragsmanager/Module/Initialize.cs
+++ b/Vortragsmanager/Module/Initialize.cs
@@ -91,7 +91,7 @@ namespace Vortragsmanager.Module
                 new Talk(39, "Jesus Christus hat die Welt besiegt – wie und wann?"),
                 new Talk(40, "Was die nahe Zukunft bringt"), //Dieser Vortrag sollte nicht mehr gehalten werden -> Neue Disposition
                 new Talk(41, "„Bleibt stehen und seht, wie Jehova euch rettet“"),
-                new Talk(42, "Wie wirkt sich Gottes Königreich auf unser Leben aus?"),
+                new Talk(42, "Kann Liebe Hass besiegen?"),
                 new Talk(43, "Tue ich, was Gott von mir erwartet?"),
                 new Talk(44, "Was bringen uns die Lehren Jesu?"),
                 new Talk(45, "Den „Weg zum Leben“ gehen"),
@@ -119,7 +119,7 @@ namespace Vortragsmanager.Module
                 new Talk(67, "Über Gottes Wort und die Schöpfung intensiv nachdenken"),
                 new Talk(68, "Vergeben wir einander weiterhin großzügig"),
                 new Talk(69, "Warum ist es wichtig, dass wir selbstlose Liebe zeigen?"),
-                new Talk(70, "Voll und ganz auf Jehova vertrauen", false), //Dieser Vortrag sollte nicht mehr gehalten werden
+                new Talk(70, "Warum Gott unser ganzes Vertrauen verdient", true), //Dieser Vortrag wurde ersetzt
                 new Talk(71, "Warum wir „wach bleiben“ müssen"),
                 new Talk(72, "Liebe – das Kennzeichen wahrer Christen"),
                 new Talk(73, "„Ein weises Herz bekommen“ – wie?"),
@@ -157,7 +157,7 @@ namespace Vortragsmanager.Module
                 new Talk(105, "In allen unseren Prüfungen Trost finden"),
                 new Talk(106, "Die Zerstörung der Erde wird von Gott bestraft"),
                 new Talk(107, "Was bringt mir ein gut geschultes Gewissen?"),
-                new Talk(108, "Die Angst vor der Zukunft überwinden"),
+                new Talk(108, "Wir können zuversichtlich in die Zukunft schauen!"),
                 new Talk(109, "Das Königreich Gottes ist nah"),
                 new Talk(110, "Gott steht in einer glücklichen Familie an erster Stelle"),
                 new Talk(111, "Kann die Menschheit vollständig geheilt werden?"),

--- a/Vortragsmanager/Module/Initialize.cs
+++ b/Vortragsmanager/Module/Initialize.cs
@@ -244,9 +244,9 @@ namespace Vortragsmanager.Module
                 new Talk(192, "Bin ich auf dem Weg zum ewigen Leben?"),
                 new Talk(193, "In der „schweren Zeit“ gerettet werden"),
                 new Talk(194, "Wie göttliche Weisheit uns zugutekommt"),
-                new Talk(12322, "Echte Hoffnung - wo zu finden?"),
-                new Talk(12323, "Wir können zuversichtlich in die Zukunft schauen!"),
-                new Talk(12324, "Die Auferstehung – der Sieg über den Tod"),
+                new Talk(12322, "Echte Hoffnung - wo zu finden?"), //ToDo: wurde zu Vortrag #62
+                new Talk(12323, "Wir können zuversichtlich in die Zukunft schauen!"), //wurde zu Vortrag #108
+                new Talk(12324, "Die Auferstehung – der Sieg über den Tod"), //wird zu Vortrag #132
                 new Talk(-1, "Unbekannt", false),
                 new Talk(-24, "Was Gottes Herrschaft für uns bewirken kann", false)
             };

--- a/Vortragsmanager/Module/IoExcel.cs
+++ b/Vortragsmanager/Module/IoExcel.cs
@@ -878,7 +878,7 @@ namespace Vortragsmanager.Module
                         while ((int)startDate.DayOfWeek != (int)DateCalcuation.Wochentag)
                             startDate = startDate.AddDays(1);
                         var row = 2;
-                        while (startDate < endDate)
+                        while (startDate <= endDate)
                         {
                             try
                             {

--- a/Vortragsmanager/Module/Update.cs
+++ b/Vortragsmanager/Module/Update.cs
@@ -69,6 +69,8 @@ namespace Vortragsmanager.Module
                 {
                     TalkList.Reset();
                 }
+
+
             }
 
             //auf aktuellste Version setzen = 25 (siehe oben)

--- a/Vortragsmanager/Module/Update.cs
+++ b/Vortragsmanager/Module/Update.cs
@@ -18,7 +18,7 @@ namespace Vortragsmanager.Module
         /// Module.Update für C# Updates (Inhalte)
         /// Changelog.md
         /// </summary>
-        public static int CurrentVersion => 29;
+        public static int CurrentVersion => 30;
 
         public static void Process()
         {
@@ -49,8 +49,16 @@ namespace Vortragsmanager.Module
                 }
             }
 
+            //Vorträge die nicht mehr gehalten werden sollen
+            if (DataContainer.Version < 29)
+            {
+                FindFutureTalk(112, new DateTime(2023,6,1));
+                FindFutureTalk(131, new DateTime(2023,9,1));
+                FindFutureTalk(132, new DateTime(2023,9,1));
+            }
+
             //Aktualisierte Vorträge, hier kann der Updatebefehl mehrfach genutzt werden. Einfach die neue Programmversion in der nächsten Zeile eintragen.
-            if (DataContainer.Version < 28)
+            if (DataContainer.Version < 30)
             {
                 var inhalt = "Es gibt geänderte Vortragsthemen. Du kannst die Themen jetzt aktualisieren. Damit werden individuelle Änderungen die du in der Vergangenheit an den Vortragsthemen vorgenommen hast gelöscht." + Environment.NewLine +
     "Du kannst die Änderung auch später unter 'Vorträge' -> 'Zurücksetzen' durchführen." + Environment.NewLine +
@@ -61,14 +69,6 @@ namespace Vortragsmanager.Module
                 {
                     TalkList.Reset();
                 }
-            }
-
-            //Vorträge die nicht mehr gehalten werden sollen
-            if (DataContainer.Version < 29)
-            {
-                FindFutureTalk(112, new DateTime(2023,6,1));
-                FindFutureTalk(131, new DateTime(2023,9,1));
-                FindFutureTalk(132, new DateTime(2023,9,1));
             }
 
             //auf aktuellste Version setzen = 25 (siehe oben)

--- a/Vortragsmanager/PageModels/MeinPlanVorsitzUndLeserEinstellungenPage.cs
+++ b/Vortragsmanager/PageModels/MeinPlanVorsitzUndLeserEinstellungenPage.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.ObjectModel;
 using System.Linq;
+using System.Windows.Forms;
 using DevExpress.Mvvm;
+using DevExpress.Xpf.Core;
 using Vortragsmanager.DataModels;
 using Vortragsmanager.UserControls;
 
@@ -16,18 +18,46 @@ namespace Vortragsmanager.PageModels
             }
 
             ButtonNewCommand = new DelegateCommand(ButtonNew);
+            ButtonDeleteCommand = new DelegateCommand(ButtonDelete);
         }
 
         public ObservableCollection<SonntagEinstellungenItem> Personen { get; } = new ObservableCollection<SonntagEinstellungenItem>();
+
+        public SonntagEinstellungenItem SelectedPerson { get; set; }
 
         public static Conregation Versammlung => DataContainer.MeineVersammlung;
 
         public DelegateCommand ButtonNewCommand { get; }
 
+        public DelegateCommand ButtonDeleteCommand { get; }
+
         private void ButtonNew()
         {
             var az = DataContainer.AufgabenZuordnungAdd();
             Personen.Add(new SonntagEinstellungenItem(az));
+        }
+
+        private void ButtonDelete()
+        {
+            if (SelectedPerson == null)
+            {
+                ThemedMessageBox.Show("Information", "Bitte die zu löschende Person auswählen", System.Windows.MessageBoxButton.OK);
+                return;
+            }
+
+            //Alle Zuordnungen der Person entfernen, dann die Person selber entfernen
+            foreach (var p in DataContainer.AufgabenPersonKalender.Where(x=> x.Vorsitz == SelectedPerson.Person))
+            {
+                p.Vorsitz = null;
+            }
+            foreach (var p in DataContainer.AufgabenPersonKalender.Where(x => x.Leser == SelectedPerson.Person))
+            {
+                p.Leser = null;
+            }
+
+            var apz = DataContainer.AufgabenPersonZuordnung.First(x => x == SelectedPerson.Person);
+            DataContainer.AufgabenPersonZuordnung.Remove(apz);
+            Personen.Remove(SelectedPerson);
         }
 
         public int MonateAnzahlAnzeige

--- a/Vortragsmanager/PageModels/MeineRednerKalenderPageModel.cs
+++ b/Vortragsmanager/PageModels/MeineRednerKalenderPageModel.cs
@@ -6,6 +6,7 @@ using DevExpress.Mvvm;
 using Vortragsmanager.DataModels;
 using Vortragsmanager.Enums;
 using Vortragsmanager.Helper;
+using Vortragsmanager.Properties;
 using Vortragsmanager.Windows;
 
 namespace Vortragsmanager.PageModels
@@ -37,6 +38,8 @@ namespace Vortragsmanager.PageModels
                 Redner.Add(box);
             }
             //Talks = Core.DataContainer.ExternerPlan;//.Where(x => x.Datum.Year == CurrentYear);
+            //Laden der Optionen
+            
             ChangeCurrentYear(0);
         }
 
@@ -80,6 +83,12 @@ namespace Vortragsmanager.PageModels
             {
                 list = list.Where(x => x.Kw >= DateCalcuation.CurrentWeek).ToList();
                 listIntern = listIntern.Where(x => x.Kw >= DateCalcuation.CurrentWeek);
+            }
+
+            if (OneYearOnly)
+            {
+                list = list.Where(x => x.Datum.Year == CurrentYear).ToList();
+                listIntern = listIntern.Where(x => x.Kw < CurrentYear*100).ToList();
             }
 
             foreach (var item in listIntern)
@@ -160,8 +169,26 @@ namespace Vortragsmanager.PageModels
 
         public bool History
         {
-            get { return GetProperty(() => History); }
-            set { SetProperty(() => History, value, ApplyFilter); }
+            get => Helper.Helper.GlobalSettings.MeineRednerHistory;
+            set
+            {
+                Helper.Helper.GlobalSettings.MeineRednerHistory = value;
+                Helper.Helper.GlobalSettings.Save();
+                RaisePropertiesChanged();
+                ApplyFilter();
+            }
+        }
+
+        public bool OneYearOnly
+        {
+            get => Helper.Helper.GlobalSettings.MeineRednerOneYearOnly;
+            set
+            {
+                Helper.Helper.GlobalSettings.MeineRednerOneYearOnly = value;
+                Helper.Helper.GlobalSettings.Save();
+                RaisePropertiesChanged();
+                ApplyFilter();
+            }
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822")]

--- a/Vortragsmanager/Pages/MeinPlanVorsitzUndLeserEinstellungenPage.xaml
+++ b/Vortragsmanager/Pages/MeinPlanVorsitzUndLeserEinstellungenPage.xaml
@@ -30,15 +30,20 @@
         </StackPanel>
         <ListBox Grid.Row="1" Grid.Column="0"
                  ItemsSource="{Binding Personen, Mode=OneWay}"
+                 SelectedItem="{Binding SelectedPerson, Mode=TwoWay}"
                  BorderThickness="0"
                  MaxWidth="680"
                  HorizontalAlignment="Left"/>
-        <Button Grid.Row="2" Grid.Column="0"
-                Content="Person hinzufügen" 
-                Command="{Binding ButtonNewCommand}" 
-                Width="150" 
-                HorizontalAlignment="Left" 
-                Margin="10,5,0,0"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="0" Margin="10,5,0,0">
+            <Button Content="Person hinzufügen" 
+                    Command="{Binding ButtonNewCommand}" 
+                    Width="150" />
+            <Button Grid.Row="2" Grid.Column="0"
+                    Content="Person löschen" 
+                    Command="{Binding ButtonDeleteCommand}" 
+                    Margin="10,0,0,0"
+                    Width="150" />
+        </StackPanel>
         <!-- Sonstige Einstellungen -->
         <Label Grid.Column="1" 
                Grid.Row="0" 

--- a/Vortragsmanager/Pages/MeineRednerKalenderPage.xaml
+++ b/Vortragsmanager/Pages/MeineRednerKalenderPage.xaml
@@ -53,6 +53,8 @@
                 </StackPanel>
                 <CheckBox Content="Historische Einträge" 
                           IsChecked="{Binding History, Mode=TwoWay}" />
+                <CheckBox Content="Nur gewähltes Jahr" 
+                          IsChecked="{Binding OneYearOnly, Mode=TwoWay}" />
                 <Label Content="Redner" Margin="0,10,0,0" FontSize="16" FontWeight="DemiBold"/>
             </StackPanel>
             <ScrollViewer Grid.Row="2" 

--- a/Vortragsmanager/UserControls/SonntagEinstellungenItem.xaml
+++ b/Vortragsmanager/UserControls/SonntagEinstellungenItem.xaml
@@ -7,7 +7,7 @@
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
              xmlns:converter="clr-namespace:Vortragsmanager.Converter"
              mc:Ignorable="d" 
-             d:DesignHeight="30" d:DesignWidth="700"
+             d:DesignHeight="30" d:DesignWidth="730"
              d:DataContext="{d:DesignInstance Type=local:SonntagEinstellungenItem}">
     <UserControl.Resources>
         <converter:DoubleToIntConverter x:Key="DoubleConverter" />
@@ -33,6 +33,7 @@
                             Precision="Full"
                             EditValue="{Binding Person.Häufigkeit, Converter={StaticResource DoubleConverter}}"
                             />
+            
         </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
* Leser und Vorsitz -Personen können gelöscht werden.
* Vorträge 42, 70, 108 aktualisiert.
* Meine Redner: neuer Filter "nur gewähltes Jahr anzeigen"
* Excel Kontaktliste: Einträge am 31.12. wurden nicht ausgegeben
* Bug behoben: Wenn ein Vortrag von einem Redner gelöscht wird, er aber noch Einladungen zu diesem Thema hat, wurde der Vortrag nicht mehr gespeichert. Diese Vorträge wurden erstmal auf "Unbekannt" gesetzt. Du kannst den Fehler beheben, indem du unter  [Historie] -> [Aktivitäten] -> [Mein Plan] -> nach der jeweiligen Versammlung des eingeladenen Redners filterst und dir die Aktivitäten Historie anschaust. Sollte es bei dir zu diesem Fehler gekommen sein, wirst du beim Update darauf hingewiesen und die betroffenen Wochen werden dir angezeigt.
