### PR TITLE
Version 1.3.43

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
-### Version 1.3.42 (03.03.2025) ###
+### Version 1.3.43 (03.03.2025) ###
 * Bug behoben: Kalenderwechsel bei Abwesenheit führt zu Absturz wenn erste Kalenderwoche des folgejahres gewählt wurde.
 * Bug behoben: Bei der Ansicht der Rednereinladung führte der Filter "Nur aktuelles Jahr" manchmal dazu das eigene Vorträge nicht angezeigt wurden.
+* Bug behoben: Breite des Feld Vortragsnummer in der Verwaltung vergrößert.
 
 ### Version 1.3.36 (28.10.2024) ###
 * Bug behoben: die erste Januar-Woche wurde unter Umständen im Aushang nicht mit ausgegeben.

--- a/MSIX Installer/Package.appxmanifest
+++ b/MSIX Installer/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="35915ThomasRamm.VortragsmanagerDeLuxe"
     Publisher="CN=3F6D9573-0790-40CA-9158-85C9F4F3D092"
-    Version="1.3.42.0" />
+    Version="1.3.43.0" />
 
   <Properties>
     <DisplayName>Vortragsmanager DeLuxe</DisplayName>

--- a/Vortragsmanager/Pages/VerwaltungVorträgePage.xaml
+++ b/Vortragsmanager/Pages/VerwaltungVorträgePage.xaml
@@ -27,7 +27,7 @@
                                         ShowGroupPanel="False"
                                         GetIsEditorActivationAction="TableView_GetIsEditorActivationAction"/>
                 </dxg:GridControl.View>
-                <dxg:GridColumn FieldName="Nummer" IsSmart="True" AllowEditing="False" ReadOnly="True" Header="Nr" Width="40" AllowResizing="False" FixedWidth="True"/>
+                <dxg:GridColumn FieldName="Nummer" IsSmart="True" AllowEditing="False" ReadOnly="True" Header="Nr" Width="50" AllowResizing="False" FixedWidth="True"/>
                 <dxg:GridColumn FieldName="Thema" IsSmart="True" AllowEditing="True" Width="120" AllowedSortOrders="All" />
                 <dxg:GridColumn FieldName="Gültig" IsSmart="True" AllowEditing="True" Width="50" AllowResizing="False" FixedWidth="True">
                     <dxg:GridColumn.EditSettings>

--- a/Vortragsmanager/Properties/AssemblyInfo.cs
+++ b/Vortragsmanager/Properties/AssemblyInfo.cs
@@ -43,6 +43,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.37.*")]
+[assembly: AssemblyVersion("1.3.43.*")]
 //[assembly: AssemblyFileVersion("0.9.0.0")]
 [assembly: NeutralResourcesLanguage("de-DE")]


### PR DESCRIPTION
* Bug behoben: Kalenderwechsel bei Abwesenheit führt zu Absturz wenn erste Kalenderwoche des Folgejahres gewählt wurde.
* Bug behoben: Bei der Ansicht der Rednereinladung führte der Filter "Nur aktuelles Jahr" manchmal dazu das eigene Vorträge nicht angezeigt wurden.
* Bug behoben: Breite des Feld Vortragsnummer in der Verwaltung vergrößert.